### PR TITLE
feat: add graphos to router-template CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/Dockerfile @apollographql/graphos


### PR DESCRIPTION
GraphOS should be pinged when there's a new router version released so that we can update the latest container (ie on PRs like #102).